### PR TITLE
toggle devnet tests with pytest mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Differences include:
 - no longer support python 3.9
 - test on ubuntu-latest
 - fewer direct dependencies
-- target py312 in black
+- fewer lint tools (ruff replaces black, isort, flake8, and pylint)
+- only pytest for testing (no tox)
 
 
 ## Installation
 ```bash
 clone the repo
 uv pip install -e .
-``
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,15 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.pytest.ini_options]
+markers = [
+    "dev: test devnet (deselect with '-m dev')",
+]
+addopts = [
+  "-m not dev",
+  "-r A",
+  "--tb=long",
+  "--verbosity=2",
+  "--log-cli-level=INFO",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "hundred-x"
+name = "hundred-keks"
 version = "0.1.16"
 authors = [
     { name = "8baller", email = "8ball030@gmail.com" },
@@ -11,60 +11,10 @@ readme = "README.md"
 dependencies = [
   "eip712-structs@git+https://github.com/wakamex/py-eip712-structs.git",
   "web3",
-  "safe-pysha3",
 ]
 
 [project.optional-dependencies]
-test = [
-    "pytest",
-]
-dev = [
-    "poetry",
-    "tox-gh-actions",
-    "tox-poetry",
-    "isort",
-    "pylint",
-    "pytest",
-    "black",
-    "flake8",
-    "semver",
-    "tbump",
-]
-all = [
-    "hundred-x[test, dev]",
-]
-
-
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 120
-skip_gitignore = true
-# you can skip files as below
-#skip_glob = docs/conf.py
-
-[tool.black]
-line-length = 120
-skip-string-normalization = true
-target-version = ['py312']
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
+dev = ["pytest"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -rA --verbosity=2 --log-cli-level=INFO

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -382,3 +382,19 @@ class Testnet(TestCase):
         Test the set_referral_code method of the Client class.
         """
         self.client.login()
+
+
+@pytest.mark.dev
+class Devnet(Testnet):
+    """
+    Base class for the Client class tests.
+    """
+
+    environment: Environment
+
+    def setUp(self):
+        """
+        Set up the Client class tests.
+        """
+        self.environment = Environment.DEVNET
+        self.client = HundredXClient(env=self.environment, private_key=TEST_PRIVATE_KEY, subaccount_id=1)


### PR DESCRIPTION
- move pytest.ini into pyproject.toml
- fix name in pyproject.toml
- remove black, isort, flake8, and pylint in favor of Ruff
- remove safe-pysha3 dependency